### PR TITLE
pass args untouched

### DIFF
--- a/lib/Routes/Tiny/Match.pm
+++ b/lib/Routes/Tiny/Match.pm
@@ -18,6 +18,13 @@ sub params {
     return $self->{params};
 }
 
+sub arguments {
+    my $self = shift;
+
+    return $self->{arguments};
+}
+
+
 sub name {
     my $self = shift;
 
@@ -53,6 +60,12 @@ Get original route's pattern name.
 =head2 C<params>
 
     my $params_hashref = $match->params;
+
+Get params.
+
+=head2 C<arguments>
+
+    my $arguments_hashref = $match->arguments;
 
 Get params.
 

--- a/lib/Routes/Tiny/Pattern.pm
+++ b/lib/Routes/Tiny/Pattern.pm
@@ -48,7 +48,7 @@ sub match {
             $params->{$capture} = $value;
         }
     }
-    return $self->_build_match(name => $self->name, params => $params, args => $self->{args} );
+    return $self->_build_match(name => $self->name, params => $params, arguments => $self->{arguments} );
 }
 
 sub build_path {


### PR DESCRIPTION
Allows to pass arbitrary args with matching object, like this:
$router->add_route( $uri, args => { handler => $handler });

and later:

$match = $router->match( $uri );
print $match->{args}->{handler};
