### PR TITLE
build_path and query parameters

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,6 +34,9 @@ WriteMakefile(
         )
     ),
 
-    PREREQ_PM => {'Carp' => '0'},
+    PREREQ_PM => {
+        'Carp'        => '0',
+        'URI::Escape' => '0'
+    },
     test      => {TESTS  => 't/*.t t/*/*.t t/*/*/*.t t/*/*/*/*.t'}
 );

--- a/lib/Routes/Tiny/Pattern.pm
+++ b/lib/Routes/Tiny/Pattern.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Routes::Tiny::Match;
+use URI::Escape qw(uri_escape);
 
 my $TOKEN = '[^\/()]+';
 
@@ -94,7 +95,7 @@ sub build_path {
                     }
                 }
 
-                my $param = $params{$name};
+                my $param = delete $params{$name};
 
                 if (defined(my $constraint = $part->{constraint})) {
                     Carp::croak("Param '$name' fails a constraint")
@@ -120,7 +121,7 @@ sub build_path {
                     }
                 }
 
-                $path .= $params{$name};
+                $path .= delete $params{$name};
             }
             elsif ($type eq 'text') {
                 $path .= $part->{text};
@@ -138,6 +139,10 @@ sub build_path {
 
     if ($path ne '/' && $trailing_slash) {
         $path .= q{/};
+    }
+
+    if (%params) {
+        $path .= '?'.join('&', map { uri_escape($_).'='.uri_escape($params{$_}) } keys %params);
     }
 
     return $path;


### PR DESCRIPTION
Please add ability to push all extra build_path method parameters to query parameters
e.g.

``` perl
$r->add_route('/item/:type', name=> 'item');
$r->build_path('item', type => 'newtype', extra => 1); # gives /item/newtype?extra=1
```
