### PR TITLE
fix optional param at route beginning

### DIFF
--- a/lib/Routes/Tiny/Pattern.pm
+++ b/lib/Routes/Tiny/Pattern.pm
@@ -201,7 +201,7 @@ sub _prepare_pattern {
     return $self->{pattern} if ref $self->{pattern} eq 'Regexp';
 
     my $pattern = $self->{pattern};
-    if ($pattern !~ m{ \A / }xms) {
+    if ($pattern !~ m{ \A ( / | \(/.+?\)\?/ ) }xms) {
         $pattern = q{/} . $pattern;
     }
 

--- a/t/match-with-optional.t
+++ b/t/match-with-optional.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 18;
+use Test::More tests => 20;
 
 use Routes::Tiny;
 
@@ -65,3 +65,12 @@ $m = $r->match('2009/month08/2');
 is_deeply($m->params, {year => 2009, month => '08', day => 2});
 is($r->build_path('route', year => 2009, month => '08', day => 2),
     '/2009/month08/2');
+
+$r = Routes::Tiny->new;
+$r->add_route('(/:year)?/:month/:day', name => 'route');
+
+$m = $r->match('/2009/12/2');
+is_deeply($m->params, {year => 2009, month => 12, day => 2});
+
+$m = $r->match('/12/2');
+is_deeply($m->params, {year => undef, month => 12, day => 2});


### PR DESCRIPTION
Есть возможность использовать опциональный параметр в URL '(:param)?' . Проблема в том, что если этот параметр стоит в начали паттерна в нему будет автоматически прилеплен '/'. В итоге вот такой роут нормально не матчился:
    $r->add_route('(/:year)?/:month/:day', name => 'route');
    $m = $r->match('/2009/12/2');
