### PR TITLE
support Moose type constraints

### DIFF
--- a/lib/Routes/Tiny/Pattern.pm
+++ b/lib/Routes/Tiny/Pattern.pm
@@ -94,6 +94,8 @@ sub match {
 sub _validate_type {
     my($self, $name, $param) = @_;
 
+    return 1 if not defined $param;
+
     # Valid if there are no constraints, or if it matches ANY of the constraints.
     if (defined(my $type_constraints = $self->{type_constraints}->{$name})) {
         if(@$type_constraints > 0) {

--- a/t/match-with-constraints.t
+++ b/t/match-with-constraints.t
@@ -39,4 +39,20 @@ subtest 'contraint as array' => sub {
     ok!$r->match('/articles/a');
 };
 
+subtest 'moose type constraints' => sub {
+
+    use MooseX::Types::Moose qw/Int/;
+
+    my $r = Routes::Tiny->new;
+
+    $r->add_route(
+        '/articles/:id',
+        name        => 'article',
+        constraints => {id => Int}
+    );
+
+    ok $r->match('/articles/1');
+    ok!$r->match('/articles/a');
+};
+
 done_testing;

--- a/t/match-with-constraints.t
+++ b/t/match-with-constraints.t
@@ -46,13 +46,17 @@ subtest 'moose type constraints' => sub {
     my $r = Routes::Tiny->new;
 
     $r->add_route(
-        '/articles/:id',
+        '/articles/:id(/:page)?',
         name        => 'article',
-        constraints => {id => Int}
+        constraints => {id => Int, page => Int}
     );
 
     ok $r->match('/articles/1');
     ok!$r->match('/articles/a');
+
+    ok $r->match('/articles/1/2');
+    ok!$r->match('/articles/1/a');
+
 };
 
 done_testing;


### PR DESCRIPTION
I'm working on implementing reversible, config-based routes at ZipRecruiter, and this module seems the closest to what we need, except for one use case it doesn't yet address.  We have routes that need to be disambiguated based on constraints other than regexes.  For example, the two routes below would use the same regex:

  /jobs/:state (e.g. /jobs/ohio)
  /jobs/:title (e.g. /jobs/accountant)

So a regex constraint won't meet our needs.  But with the patch I'm submittting, the below works like a charm:

  use MooseX::Types::Moose qw/Str/;

  # match known state names first
  subtype StateName, as Str, where { is_valid_state_name($_) };
  $routes->add_route( '/jobs/:state', constraints => {state => StateName} );

  # if it's not a state, it's a job title
  $routes->add_route( '/jobs/:jobtitle' );
