### PR TITLE
fix bug: correct parent of match on sub-subroute

### DIFF
--- a/lib/Routes/Tiny/Match.pm
+++ b/lib/Routes/Tiny/Match.pm
@@ -35,15 +35,7 @@ sub captures {
 sub cascading_captures {
     my $self = shift;
 
-    my $captures = { %{$self->captures} };
-
-    if($self->parent) {
-        my $parent_captures = $self->parent->captures;
-
-        for my $key (keys %$parent_captures) {
-            $captures->{$key} //= $parent_captures->{$key};
-        }
-    }
+    my $captures = $self->captures;
 
     return $self->parent ? {
         %{$self->parent->cascading_captures},

--- a/lib/Routes/Tiny/Match.pm
+++ b/lib/Routes/Tiny/Match.pm
@@ -13,7 +13,7 @@ sub new {
     $self->{name}      = $params{name};
     $self->{arguments} = $params{arguments};
     $self->{captures}  = $params{captures};
-    $self->{parent}    = undef;
+    $self->{parent}    = $params{parent};
 
     return $self;
 }

--- a/lib/Routes/Tiny/Match.pm
+++ b/lib/Routes/Tiny/Match.pm
@@ -41,13 +41,7 @@ sub cascading_captures {
         my $parent_captures = $self->parent->captures;
 
         for my $key (keys %$parent_captures) {
-            if(exists $captures->{$key}) {
-                my $parent_capture = $parent_captures->{$key};
-                $captures->{$key} = [
-                    (ref $parent_capture eq 'ARRAY' ? @$parent_capture : $parent_capture),
-                    $captures->{$key}
-                ];
-            }
+            $captures->{$key} //= $parent_captures->{$key};
         }
     }
 

--- a/lib/Routes/Tiny/Match.pm
+++ b/lib/Routes/Tiny/Match.pm
@@ -32,6 +32,31 @@ sub captures {
     return $self->{captures};
 }
 
+sub cascading_captures {
+    my $self = shift;
+
+    my $captures = { %{$self->captures} };
+
+    if($self->parent) {
+        my $parent_captures = $self->parent->captures;
+
+        for my $key (keys %$parent_captures) {
+            if(exists $captures->{$key}) {
+                my $parent_capture = $parent_captures->{$key};
+                $captures->{$key} = [
+                    (ref $parent_capture eq 'ARRAY' ? @$parent_capture : $parent_capture),
+                    $captures->{$key}
+                ];
+            }
+        }
+    }
+
+    return $self->parent ? {
+        %{$self->parent->cascading_captures},
+        %$captures
+    } : $captures;
+}
+
 sub name {
     my $self = shift;
 
@@ -82,6 +107,10 @@ Get route's pattern arguments.
     my $hashref = $match->captures;
 
 Get params.
+
+=head2 cascading_captures
+
+Get params as well as parent and ancestor params in one hash.
 
 =head2 C<params>
 

--- a/lib/Routes/Tiny/Pattern.pm
+++ b/lib/Routes/Tiny/Pattern.pm
@@ -75,14 +75,14 @@ sub match {
     my $match = $self->_build_match(
         name      => $self->name,
         arguments => $self->arguments,
-        captures  => $captures
+        captures  => $captures,
+        parent    => $args{parent}
     );
 
     if ($self->{subroutes}) {
         my $parent = $match;
         my $tail = substr($path, length $&);
-        $match = $self->{subroutes}->match($tail, %args);
-        $match->{parent} = $parent if $match;
+        $match = $self->{subroutes}->match($tail, %args, parent => $parent);
     }
 
     return $match;

--- a/t/subroutes.t
+++ b/t/subroutes.t
@@ -74,9 +74,9 @@ subtest 'pass params to subroutes' => sub {
 
 subtest 'sub-subroutes' => sub {
   my $r0 = Routes::Tiny->new;
-  $r0->mount('/toplevel/:topic', $ro);
+  $r0->mount('/toplevel/:id', $ro);
 
-  my $match = $r0->match('/toplevel/rainbows/r3/5/bar/7/');
+  my $match = $r0->match('/toplevel/22/r3/5/bar/7/');
 
   ok($match);
   if($match) {
@@ -86,13 +86,12 @@ subtest 'sub-subroutes' => sub {
     if($parent) {
       my $grandparent = $parent->parent;
       ok($grandparent);
-      is($grandparent->captures->{topic}, 'rainbows');
+      is($grandparent->captures->{id}, 22);
     }
 
     my $cascading_captures = $match->cascading_captures;
-    is($cascading_captures->{id}, 7);
+    is($cascading_captures->{id}, 7); # Id overrides grandparent id
     is($cascading_captures->{parent_id}, 5);
-    is($cascading_captures->{topic}, 'rainbows');
   }
 };
 

--- a/t/subroutes.t
+++ b/t/subroutes.t
@@ -72,4 +72,24 @@ subtest 'pass params to subroutes' => sub {
     ok $ro->match('/subroute/foo', method => 'POST');
 };
 
+subtest 'sub-subroutes' => sub {
+  my $r0 = Routes::Tiny->new;
+  $r0->mount('/toplevel/:topic', $ro);
+
+  my $match = $r0->match('/toplevel/rainbows/r3/5/bar/7/');
+
+  ok($match);
+  if($match) {
+    my $parent = $match->parent;
+    ok($parent);
+    is($parent->captures->{parent_id}, 5);
+    if($parent) {
+      my $grandparent = $parent->parent;
+      ok($grandparent);
+      is($grandparent->captures->{topic}, 'rainbows');
+    }
+  }
+};
+
+
 done_testing;

--- a/t/subroutes.t
+++ b/t/subroutes.t
@@ -88,6 +88,11 @@ subtest 'sub-subroutes' => sub {
       ok($grandparent);
       is($grandparent->captures->{topic}, 'rainbows');
     }
+
+    my $cascading_captures = $match->cascading_captures;
+    is($cascading_captures->{id}, 7);
+    is($cascading_captures->{parent_id}, 5);
+    is($cascading_captures->{topic}, 'rainbows');
   }
 };
 


### PR DESCRIPTION
- Fixed a small bug: parent of match on subroute set incorrectly to parent of parent (see test case).
- Add 'Match::cascading_captures' to get all params for subroutes and parent in one hash.