### PR TITLE
Add syntax sugar for method definition at add_route()

### DIFF
--- a/lib/Routes/Tiny.pm
+++ b/lib/Routes/Tiny.pm
@@ -30,15 +30,8 @@ sub new {
 
 sub add_route {
     my $self = shift;
-    my ($pattern, @args) = @_;
 
-    $pattern = $self->_build_pattern(
-        strict_trailing_slash => $self->{strict_trailing_slash},
-        default_method		  => $self->{default_method},
-        routes                => $self,
-        pattern               => $pattern,
-        @args
-    );
+    my $pattern = $self->_build_pattern(@_);
 
     push @{$self->{patterns}}, $pattern;
 
@@ -99,7 +92,32 @@ sub _register_pattern_name {
     }
 }
 
-sub _build_pattern { shift; return Routes::Tiny::Pattern->new(@_) }
+sub _build_pattern {
+    my $self = shift;
+
+    if (@_ % 2) {
+        unshift(@_, 'pattern');
+    } else {
+        my $method  = shift;
+        my $pattern = shift;
+
+        if ($method =~ /^(GET|HEAD|POST|PUT|DELETE|TRACE|OPTIONS|CONNECT|PATCH)$/i) {
+            unshift(@_, pattern => $pattern);
+            unshift(@_, method  => $method);
+        } else {
+            Carp::croak("Unknown pattern http method '$_[0]'");
+        }
+    }
+
+    return Routes::Tiny::Pattern->new(
+        strict_trailing_slash => $self->{strict_trailing_slash},
+        default_method        => $self->{default_method},
+        routes                => $self,
+        @_
+    )
+}
+
+
 
 1;
 __END__

--- a/lib/Routes/Tiny.pm
+++ b/lib/Routes/Tiny.pm
@@ -155,6 +155,7 @@ Routes::Tiny - Routes
     my $captures_hashref = $match->captures;
 
     # Matching with method
+    $routes->add_route('/hello/world', method => 'GET');
     my $match = $routes->match('/hello/world', method => 'GET');
 
     # Subroutes
@@ -241,6 +242,24 @@ It is possible to pass arguments to the match object AS IS.
     # $path is '/articles/123'
 
 It is possible to reconstruct a path from route's name and parameters.
+
+=head2 C<Matching with methods>
+
+    # Exact HTTP method definition
+    $routes->add_route('/articles', method => 'GET', defaults => {action => 'list'});
+
+    # Sweeter method definition
+    # METHOD => PATTERN should goes as first parameters to add_route()
+    $routes->add_route(PUT => '/articles', defaults => {action => 'create'});
+
+    $match = $routes->match('/articles', method => 'GET');
+    # $m->captures is {action => 'list'}
+
+    $match = $routes->match('/articles', method => 'PUT');
+    # $m->captures is {action => 'create'}
+
+
+It is possible to specify HTTP method for route
 
 =head2 C<Subroutes>
 

--- a/t/method.t
+++ b/t/method.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 9;
+use Test::More tests => 11;
 
 use Routes::Tiny;
 
@@ -23,3 +23,7 @@ ok(!$r->match('photos/1', method => 'head'));
 
 $r->add_route('/logout', method => 'gEt');
 ok($r->match('logout', method => 'geT'));
+
+$r->add_route(POST => '/users/:id');
+ok(!$r->match('users/1'));
+ok($r->match('users/1', method => 'post'));


### PR DESCRIPTION
Allow to add routes with HTTP method little bit nice.
Example: `$r->add_route(POST => '/users/:id')`