### PR TITLE
Die on routes like "/foo/;id" which is most (all?) of the time a typo.

### DIFF
--- a/lib/Routes/Tiny.pm
+++ b/lib/Routes/Tiny.pm
@@ -16,6 +16,7 @@ sub new {
     my $self = {};
     bless $self, $class;
 
+    $self->{strict_placeholder_separator} = $params{strict_placeholder_separator};
     $self->{strict_trailing_slash} = $params{strict_trailing_slash};
     $self->{strict_case} = $params{strict_case};
     $self->{default_method} = $params{default_method};
@@ -23,6 +24,10 @@ sub new {
     $self->{parent_pattern}        = undef;
     $self->{patterns}              = [];
     $self->{names}                 = {};
+
+    $self->{strict_placeholder_separator} = 1
+      unless defined $self->{strict_placeholder_separator};
+
     $self->{strict_trailing_slash} = 1
       unless defined $self->{strict_trailing_slash};
     $self->{strict_case} = 1
@@ -113,6 +118,7 @@ sub _build_pattern {
     }
 
     return Routes::Tiny::Pattern->new(
+        strict_placeholder_separator => $self->{strict_placeholder_separator},
         strict_trailing_slash => $self->{strict_trailing_slash},
         strict_case           => $self->{strict_case},
         default_method        => $self->{default_method},

--- a/lib/Routes/Tiny/Pattern.pm
+++ b/lib/Routes/Tiny/Pattern.pm
@@ -28,6 +28,7 @@ sub new {
     $self->{constraints}    = $params{constraints} || {};
     $self->{routes}         = $params{routes};
     $self->{subroutes}      = $params{subroutes};
+    $self->{strict_placeholder_separator} = $params{strict_placeholder_separator};
     $self->{strict_trailing_slash} = $params{strict_trailing_slash};
     $self->{strict_case}    = $params{strict_case};
 
@@ -289,6 +290,9 @@ sub _prepare_pattern {
         }
         elsif ($pattern =~ m{ \G ($TOKEN) }gcxms) {
             my $text = $1;
+            if ( $self->{strict_placeholder_separator} && $text =~ m{ \A [;] }xms ) {
+                Carp::croak("Possible typo: route part starts with a semi-colon instead of a colon in `$text`");
+            }
             $re .= quotemeta $text;
 
             push @$part, {type => 'text', text => $text};


### PR DESCRIPTION
However, it might be better to have this turned off by default.
It is turned on in the commit to follow the convention of similar
flags.